### PR TITLE
Use torch.accelerate API in word language model example

### DIFF
--- a/run_python_examples.sh
+++ b/run_python_examples.sh
@@ -153,7 +153,7 @@ function vision_transformer() {
 }
 
 function word_language_model() {
-  uv run main.py --epochs 1 --dry-run $CUDA_FLAG --mps || error "word_language_model failed"
+  uv run main.py --epochs 1 --dry-run $ACCEL_FLAG || error "word_language_model failed"
 }
 
 function gcn() {

--- a/word_language_model/README.md
+++ b/word_language_model/README.md
@@ -4,13 +4,13 @@ This example trains a multi-layer RNN (Elman, GRU, or LSTM) or Transformer on a 
 The trained model can then be used by the generate script to generate new text.
 
 ```bash
-python main.py --cuda --epochs 6           # Train a LSTM on Wikitext-2 with CUDA.
-python main.py --cuda --epochs 6 --tied    # Train a tied LSTM on Wikitext-2 with CUDA.
-python main.py --cuda --tied               # Train a tied LSTM on Wikitext-2 with CUDA for 40 epochs.
-python main.py --cuda --epochs 6 --model Transformer --lr 5
+python main.py --accel --epochs 6           # Train a LSTM on Wikitext-2 with CUDA.
+python main.py --accel --epochs 6 --tied    # Train a tied LSTM on Wikitext-2 with CUDA.
+python main.py --accel --tied               # Train a tied LSTM on Wikitext-2 with CUDA for 40 epochs.
+python main.py --accel --epochs 6 --model Transformer --lr 5
                                            # Train a Transformer model on Wikitext-2 with CUDA.
 
-python generate.py                         # Generate samples from the default model checkpoint.
+python generate.py --accel                       # Generate samples from the default model checkpoint.
 ```
 
 The model uses the `nn.RNN` module (and its sister modules `nn.GRU` and `nn.LSTM`) or Transformer module (`nn.TransformerEncoder` and `nn.TransformerEncoderLayer`) which will automatically use the cuDNN backend if run on CUDA with cuDNN installed.
@@ -35,8 +35,7 @@ optional arguments:
   --dropout DROPOUT     dropout applied to layers (0 = no dropout)
   --tied                tie the word embedding and softmax weights
   --seed SEED           random seed
-  --cuda                use CUDA
-  --mps                 enable GPU on macOS
+  --accel               activate support for an accelerator card
   --log-interval N      report interval
   --save SAVE           path to save the final model
   --onnx-export ONNX_EXPORT
@@ -49,8 +48,8 @@ With these arguments, a variety of models can be tested.
 As an example, the following arguments produce slower but better models:
 
 ```bash
-python main.py --cuda --emsize 650 --nhid 650 --dropout 0.5 --epochs 40
-python main.py --cuda --emsize 650 --nhid 650 --dropout 0.5 --epochs 40 --tied
-python main.py --cuda --emsize 1500 --nhid 1500 --dropout 0.65 --epochs 40
-python main.py --cuda --emsize 1500 --nhid 1500 --dropout 0.65 --epochs 40 --tied
+python main.py --accel --emsize 650 --nhid 650 --dropout 0.5 --epochs 40
+python main.py --accel --emsize 650 --nhid 650 --dropout 0.5 --epochs 40 --tied
+python main.py --accel --emsize 1500 --nhid 1500 --dropout 0.65 --epochs 40
+python main.py --accel --emsize 1500 --nhid 1500 --dropout 0.65 --epochs 40 --tied
 ```


### PR DESCRIPTION
- Fix compatiblity issue for pytorch 2.6+ when saving and loading the model weights
- Add accelerator API compatibility to remove specific abstraction for different hardware accelerators to allow future devices without manycode changes 
- Add flag to CI to test changes in this specific example run